### PR TITLE
Specific pysam version as 0.9.0 fails to install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -81,8 +81,8 @@ done
 
 echo "--------------------- installing Python pip etc ... ------------------------"
 easy_install pip
-pip install pysam
-pip3 install pysam
+pip install pysam==0.8.3
+pip3 install pysam==0.8.3
 pip3 install jupyter
 pip3 install bash_kernel
 python3 -m bash_kernel.install


### PR DESCRIPTION
pysam 0.9.0 doesn't install with pip so specifying version 0.8.3 for the VM.